### PR TITLE
Update plugin.modxtalksplugin.php

### DIFF
--- a/core/components/modxtalks/elements/plugins/plugin.modxtalksplugin.php
+++ b/core/components/modxtalks/elements/plugins/plugin.modxtalksplugin.php
@@ -45,7 +45,7 @@ switch ($modx->event->name) {
         $routermt->route();
         break;
     case 'OnWebPagePrerender':
-        if($modx->mt_mtCount === true) {
+        if(isset($modx->mt_mtCount)&&$modx->mt_mtCount === true){
             $corePath = $modx->getOption('modxtalks.core_path',null,$modx->getOption('core_path').'components/modxtalks/');
             require_once $corePath.'model/modxtalks/modxtalkscount.class.php';
             $counts = new modxTalksCount($modx);


### PR DESCRIPTION
Не совсем встроенная возможность, но иногда нужно отключить скрубер (это панель справа, где месяцы кол-во комментариев и т.п.). Это можно сделать переименовав шаблон чанка скрубера.

Но тогда появляется ошибка в плагине - не задан $modx->mt_mtCount

Для этого нужно поправиь 48 строчку в плагине
if($modx->mt_mtCount === true){

на
if(isset($modx->mt_mtCount)&&$modx->mt_mtCount === true){

Если не против, внесите, пожалуйста, в рабочую версию
